### PR TITLE
Fix PR on windows

### DIFF
--- a/mdtraj/tests/test_restart.py
+++ b/mdtraj/tests/test_restart.py
@@ -34,11 +34,11 @@ from mdtraj.testing import get_fn, eq, assert_allclose
 
 fd1, temp1 = tempfile.mkstemp(suffix='.rst7')
 fd2, temp2 = tempfile.mkstemp(suffix='.ncrst')
+os.close(fd1)
+os.close(fd2)
 def teardown_module(module):
     """remove the temporary file created by tests in this file
     this gets automatically called by nose"""
-    os.close(fd1)
-    os.close(fd2)
     if os.path.exists(temp1): os.unlink(temp1)
     if os.path.exists(temp2): os.unlink(temp2)
 
@@ -107,23 +107,23 @@ def test_read_write_2():
 def test_read_write_3():
     traj = md.load(get_fn('frame0.nc'), top=get_fn('native.pdb'))
     traj[0].save(temp1)
-    yield lambda: assert_true(os.path.exists(temp1))
+    assert_true(os.path.exists(temp1))
     rsttraj = md.load(temp1, top=get_fn('native.pdb'))
     assert_allclose(rsttraj.xyz, traj[0].xyz)
     os.unlink(temp1)
     traj.save(temp1)
     for i in range(traj.n_frames):
-        yield lambda: assert_true(os.path.exists('%s.%03d' % (temp1, i+1)))
+        assert_true(os.path.exists('%s.%03d' % (temp1, i+1)))
         os.unlink('%s.%03d' % (temp1, i+1))
 
 def test_read_write_4():
     traj = md.load(get_fn('frame0.nc'), top=get_fn('native.pdb'))
     traj[0].save(temp2)
-    yield lambda: assert_true(os.path.exists(temp2))
+    assert_true(os.path.exists(temp2))
     rsttraj = md.load(temp2, top=get_fn('native.pdb'))
     assert_allclose(rsttraj.xyz, traj[0].xyz)
     os.unlink(temp2)
     traj.save(temp2)
     for i in range(traj.n_frames):
-        yield lambda: assert_true(os.path.exists('%s.%03d' % (temp2, i+1)))
+        assert_true(os.path.exists('%s.%03d' % (temp2, i+1)))
         os.unlink('%s.%03d' % (temp2, i+1))


### PR DESCRIPTION
This fixes, I think, the PR failures on windows in https://github.com/mdtraj/mdtraj/pull/825.

https://ci.appveyor.com/project/rmcgibbo/mdtraj/build/1.0.372/job/jf2lmhi7kmgn865h
```
======================================================================
ERROR: Failure: WindowsError ([Error 32] The process cannot access the file because it is being used by another process: 'c:\\users\\appveyor\\appdata\\local\\temp\\tmppxsk0h.rst7')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Python27_32\envs\_test\lib\site-packages\nose\loader.py", line 251, in generate
    for test in g():
  File "c:\python27_32\envs\_test\lib\site-packages\mdtraj-1.4.0.dev0-py2.7-win32.egg\mdtraj\tests\test_restart.py", line 113, in test_read_write_3
    os.unlink(temp1)
WindowsError: [Error 32] The process cannot access the file because it is being used by another process: 'c:\\users\\appveyor\\appdata\\local\\temp\\tmppxsk0h.rst7'
 
======================================================================
ERROR: Failure: WindowsError ([Error 32] The process cannot access the file because it is being used by another process: 'c:\\users\\appveyor\\appdata\\local\\temp\\tmpypkla_.ncrst')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Python27_32\envs\_test\lib\site-packages\nose\loader.py", line 251, in generate
    for test in g():
  File "c:\python27_32\envs\_test\lib\site-packages\mdtraj-1.4.0.dev0-py2.7-win32.egg\mdtraj\tests\test_restart.py", line 125, in test_read_write_4
    os.unlink(temp2)
WindowsError: [Error 32] The process cannot access the file because it is being used by another process: 'c:\\users\\appveyor\\appdata\\local\\temp\\tmpypkla_.ncrst'
 
----------------------------------------------------------------------
Ran 1115 tests in 713.776s
 ```